### PR TITLE
Fix bluebird warning about reject called with non-error

### DIFF
--- a/lib/blob_lease.js
+++ b/lib/blob_lease.js
@@ -108,7 +108,7 @@ Lease.prototype.renew = function (options) {
   var self = this;
   return new Promise(function (resolve, reject) {
     if (!self.leaseId) {
-      reject(Lease.NotHeldError);
+      reject(new Error(Lease.NotHeldError));
     } else {
       self.blobService.renewLease(self.container, self.blob, self.leaseId, options, function (error, result, response) {
         if (error) {
@@ -127,7 +127,7 @@ Lease.prototype.release = function (options) {
   var self = this;
   return new Promise(function (resolve, reject) {
     if (!self.leaseId) {
-      reject(Lease.NotHeldError);
+      reject(new Error(Lease.NotHeldError));
     } else {
       self.blobService.releaseLease(self.container, self.blob, self.leaseId, options, function (error, result, response) {
         if (error) {
@@ -147,7 +147,7 @@ Lease.prototype.updateContents = function (text, options) {
   var self = this;
   return new Promise(function (resolve, reject) {
     if (!self.leaseId) {
-      reject(Lease.NotHeldError);
+      reject(new Error(Lease.NotHeldError));
     } else {
       var opts = _.defaults({leaseId: self.leaseId}, options || {});
       self.blobService.createBlockBlobFromText(self.container, self.blob, text, opts, function (error, result, response) {
@@ -166,7 +166,7 @@ Lease.prototype.getContents = function (options) {
   var self = this;
   return new Promise(function (resolve, reject) {
     if (!self.leaseId) {
-      reject(Lease.NotHeldError);
+      reject(new Error(Lease.NotHeldError));
     } else {
       var opts = _.defaults({leaseId: self.leaseId}, options || {});
       self.blobService.getBlobToText(self.container, self.blob, opts, function (error, text, result, response) {


### PR DESCRIPTION
I see a lot of warnings about how reject is called with non-errors

See this:
http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error

Not sure if it's the most elegant fix but that does the trick for me :) 
